### PR TITLE
Add space between sample arguments and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ npm install --save-dev typedoc typedoc-plugin-markdown
 The plugin provides an additional markdown theme:
 
 *shell:*
-```
+
+```bash
 $ node_modules/.bin/typedoc --theme markdown
 ```
 
 *npm script:*
-```
+
+```json
 "scripts": {
  "docs": "typedoc --theme markdown"
 }
@@ -34,24 +36,22 @@ $ node_modules/.bin/typedoc --theme markdown
 
 The plugin exposes the following additional arguments:
 
- * `--mdEngine<github|bitbucket|gitbook>`<br />
- The markdown rendering engine:<br /> 
- **"github":** Optimised for GitHub/CommonMark (Default).<br /> 
- **"bitbucket":** Renders markdown to support Bitbucket anchor linking and more.<br /> 
+* `--mdEngine <github|bitbucket|gitbook>`\
+ The markdown rendering engine:\
+ **"github":** Optimised for GitHub/CommonMark (Default).\
+ **"bitbucket":** Renders markdown to support Bitbucket anchor linking and more.\
  **"gitbook":** Adds SUMMARY.md file to generate a book's table of contents and sets header levels to display correct sub-navigation menu. (*Optimised for newest version of GitBook*).
 
-* `--mdHideSources`<br />
+* `--mdHideSources`\
   Suppress source file linking from output.
-  
-* `--mdSourceRepo<path.to.repo>`(*Will be ignored on GitHub repositories*)<br />
-  The source repo to use for source file linking.<br />
-  For bitbucket use: `https://bitbucket.org/owner/repository_name`. 
+
+* `--mdSourceRepo <path.to.repo>`(*Will be ignored on GitHub repositories*)\
+  The source repo to use for source file linking.\
+  For bitbucket use: `https://bitbucket.org/owner/repository_name`.
 
 ## Example output
 
-* <a href="https://github.com/tgreyjs/typedoc-plugin-markdown/tree/master/examples/out/README.md">Some general example output.</a>
-
-
+* [Some general example output](https://github.com/tgreyjs/typedoc-plugin-markdown/tree/master/examples/out/README.md).
 
 ## Acknowledgements
 


### PR DESCRIPTION
Adds a space between the additional arguments and their possible values for clarity, also cleans up some whitespace and markdown syntax.