### PR TITLE
Make turndown default to using fenced code blocks

### DIFF
--- a/src/theme/helpers/getMarkdownFromHtml.ts
+++ b/src/theme/helpers/getMarkdownFromHtml.ts
@@ -6,5 +6,7 @@ const turndownService = new TurndownService();
  * @param options
  */
 export function getMarkdownFromHtml(options: any) {
-  return turndownService.turndown(options.fn(this));
+  return turndownService.turndown(options.fn(this), {
+    codeBlockStyle: 'fenced'
+  });
 }

--- a/src/theme/helpers/getMarkdownFromHtml.ts
+++ b/src/theme/helpers/getMarkdownFromHtml.ts
@@ -7,6 +7,6 @@ const turndownService = new TurndownService();
  */
 export function getMarkdownFromHtml(options: any) {
   return turndownService.turndown(options.fn(this), {
-    codeBlockStyle: 'fenced'
+    codeBlockStyle: 'fenced',
   });
 }


### PR DESCRIPTION
This won't currently have any effect, but it will once this PR over at `turndown` is merged, so it's definitely worth prepping for:
https://github.com/domchristie/turndown/pull/226

Once that PR is merged, I've confirmed locally that `typedoc-plugin-markdown` will correctly label fenced code examples that were generated from TypeDoc.

So if you have a TS file such as:

```typescript
/**
 * Get file type settings
 *
 * ```typescript
 * const fileSettings = await getFileTypeSettings('path/to/some/file.md')
 * ```
 *
 * @public
 * @param filename - The file to get settings for.
 */
export const getFileTypeSettings = async (filename: Filename) => {/**/}
```

TypeDoc will output the HTML as such:
```html
<pre><code class="lang-typescript"><span class="hljs-keyword">const</span> fileSettings = <span class="hljs-keyword">await</span> getFileTypeSettings(<span class="hljs-string">'path/to/some/file.md'</span>)
</code></pre>
```

Currently, `turndown` doesn't process that, as it's specifically looking for a CSS class prefix of `language-` not the shorter version `lang-`. This paradigm is all based on `highlight.js` which supports `"language-*"`, `"lang-*"` or even un-prefixed as just the name of the language itself such as `"html"`.

Once that `turndown` PR lands, `turndown` will convert that HTML basically back into the original (ignore the extra space):
```
`` `typescript
const fileSettings = await getFileTypeSettings('path/to/some/file.md')
`` `
```