### PR TITLE
Fix #27 Broken parameter tabel when function has a parameter with dif…

### DIFF
--- a/src/theme/partials/member.parameters.hbs
+++ b/src/theme/partials/member.parameters.hbs
@@ -3,7 +3,7 @@
 
 {{getParametersTableHeaders parameters}}
 {{#each parameters}}
-| {{#each flags}}`{{this}}` {{/each}}{{ name }} | {{#with type}}{{>type}}{{/with}}{{#if defaultValue}} | {{defaultValue}} | {{else}} | {{/if}}{{#if comment}} {{#getMarkdownFromHtml}}{{#markdown}}{{ getStrippedComment comment }}{{/markdown}}{{/getMarkdownFromHtml}} |{{/if}}
+| {{#compact}}{{#each flags}}`{{this}}` {{/each}}{{ name }} | {{#with type}}{{>type}}{{/with}}{{#if defaultValue}} | {{defaultValue}} | {{else}} | {{/if}}{{#if comment}} {{#getMarkdownFromHtml}}{{#markdown}}{{ getStrippedComment comment }}{{/markdown}}{{/getMarkdownFromHtml}} |{{/if}}{{/compact}}
 {{/each}}
 {{getNewLine}}{{getNewLine}}
 {{/if}}

--- a/src/theme/partials/type.hbs
+++ b/src/theme/partials/type.hbs
@@ -17,9 +17,7 @@
 {{/with}}
 {{else}}
 {{#if types}}
-{{#each types}}
-{{#if @index}} {{#ifCond ../type '==' 'intersection'}}&{{else}}|{{/ifCond}}
-{{/if}}{{> type}}{{/each}}
+{{#each types}}{{#if @index}} {{#ifCond ../type '==' 'intersection'}}&{{else}}&#124;{{/ifCond}}{{/if}} {{> type}}{{/each}}
 {{else}}
 {{#if elements}} 
 {{#compact}}

--- a/test/fixtures/bitbucket/README.md
+++ b/test/fixtures/bitbucket/README.md
@@ -308,11 +308,11 @@ This is a function with a parameter that has a default value.
 
 | Param | Type | Default value |
 | ------ | ------ | ------ |
-| `Default value` valueA | `string` | &quot;defaultValue&quot; | 
-| `Default value` valueB | `number` | 100 | 
-| `Default value` valueC | `number` |  Number.NaN | 
-| `Default value` valueD | `boolean` | true | 
-| `Default value` valueE | `boolean` | false | 
+| `Default value` valueA | `string` | &quot;defaultValue&quot; |
+| `Default value` valueB | `number` | 100 |
+| `Default value` valueC | `number` |  Number.NaN |
+| `Default value` valueD | `boolean` | true |
+| `Default value` valueE | `boolean` | false |
 
 **Returns:** `string`
 The input value or the default value.

--- a/test/fixtures/bitbucket/classes/baseclass.md
+++ b/test/fixtures/bitbucket/classes/baseclass.md
@@ -59,7 +59,7 @@ This is a simple example on how to use BaseClass.
 
 | Param | Type |
 | ------ | ------ |
-| name | `string` | 
+| name | `string` |
 
 **Returns:** [BaseClass](baseclass.md)
 
@@ -69,7 +69,7 @@ This is a simple example on how to use BaseClass.
 
 | Param | Type |
 | ------ | ------ |
-| source | [BaseClass](baseclass.md) | 
+| source | [BaseClass](baseclass.md) |
 
 **Returns:** [BaseClass](baseclass.md)
 
@@ -199,10 +199,10 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| originalValues | [BaseClass](baseclass.md) | 
-| newRecord | `any` | 
-| fieldNames | `string`[] | 
-| mandatoryFields | `string`[] | 
+| originalValues | [BaseClass](baseclass.md) |
+| newRecord | `any` |
+| fieldNames | `string`[] |
+| mandatoryFields | `string`[] |
 
 **Returns:** `string`
 

--- a/test/fixtures/bitbucket/classes/color.md
+++ b/test/fixtures/bitbucket/classes/color.md
@@ -44,9 +44,9 @@
 
 | Param | Type |
 | ------ | ------ |
-| r | `number` | 
-| g | `number` | 
-| b | `number` | 
+| r | `number` |
+| g | `number` |
+| b | `number` |
 
 **Returns:** [Color](color.md)
 
@@ -130,8 +130,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Color](color.md) | 
-| v2 | [Color](color.md) | 
+| v1 | [Color](color.md) |
+| v2 | [Color](color.md) |
 
 **Returns:** [Color](color.md)
 
@@ -147,8 +147,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| k | `number` | 
-| v | [Color](color.md) | 
+| k | `number` |
+| v | [Color](color.md) |
 
 **Returns:** [Color](color.md)
 
@@ -164,8 +164,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Color](color.md) | 
-| v2 | [Color](color.md) | 
+| v1 | [Color](color.md) |
+| v2 | [Color](color.md) |
 
 **Returns:** [Color](color.md)
 
@@ -181,7 +181,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| c | [Color](color.md) | 
+| c | [Color](color.md) |
 
 **Returns:** `object`
 

--- a/test/fixtures/bitbucket/classes/genericclass.md
+++ b/test/fixtures/bitbucket/classes/genericclass.md
@@ -41,7 +41,7 @@ This a type parameter.
 
 ⊕ **new GenericClass**(p1: *`any`*, p2: *`T`*, p3: *`number`*, p4: *`number`*, p5: *`string`*): [GenericClass](genericclass.md)
 
-*Defined in [classes.ts:284](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-284)*
+*Defined in [classes.ts:293](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-293)*
 
 Constructor short text.
 
@@ -65,7 +65,7 @@ ___
 
 **● p2**: *`T`*
 
-*Defined in [classes.ts:295](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-295)*
+*Defined in [classes.ts:304](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-304)*
 
 Private string property
 
@@ -75,7 +75,7 @@ ___
 
 **● p3**: *`number`*
 
-*Defined in [classes.ts:295](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-295)*
+*Defined in [classes.ts:304](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-304)*
 
 Public number property
 
@@ -85,7 +85,7 @@ ___
 
 **● p5**: *`string`*
 
-*Defined in [classes.ts:295](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-295)*
+*Defined in [classes.ts:304](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-304)*
 
 Readonly property
 
@@ -95,7 +95,7 @@ ___
 
 **● value**: *`T`*
 
-*Defined in [classes.ts:284](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-284)*
+*Defined in [classes.ts:293](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-293)*
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 ▸ **getValue**(): `T`
 
-*Defined in [classes.ts:305](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-305)*
+*Defined in [classes.ts:314](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-314)*
 
 **Returns:** `T`
 
@@ -115,7 +115,7 @@ ___
 
 ▸ **setValue**(value: *`T`*): `void`
 
-*Defined in [classes.ts:301](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-301)*
+*Defined in [classes.ts:310](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-310)*
 
 **Parameters:**
 

--- a/test/fixtures/bitbucket/classes/internalclass.md
+++ b/test/fixtures/bitbucket/classes/internalclass.md
@@ -30,7 +30,7 @@ This is an internal class, it is not exported.
 
 | Param | Type |
 | ------ | ------ |
-| options | `object` | 
+| options | `object` |
 
 **Returns:** [InternalClass](internalclass.md)
 

--- a/test/fixtures/bitbucket/classes/mythirdclass.md
+++ b/test/fixtures/bitbucket/classes/mythirdclass.md
@@ -30,7 +30,7 @@
 
 | Param | Type |
 | ------ | ------ |
-| arg | [MyFourthClass](myfourthclass.md)<[MyFirstClass](myfirstclass.md), [MySecondClass](mysecondclass.md)<[MyFirstClass](myfirstclass.md)>> | 
+| arg | [MyFourthClass](myfourthclass.md)<[MyFirstClass](myfirstclass.md), [MySecondClass](mysecondclass.md)<[MyFirstClass](myfirstclass.md)>> |
 
 **Returns:** [MyThirdClass](mythirdclass.md)
 

--- a/test/fixtures/bitbucket/classes/nongenericclass.md
+++ b/test/fixtures/bitbucket/classes/nongenericclass.md
@@ -38,7 +38,7 @@ This a non generic class derived from a [generic class](genericclass.md).
 
 *Inherited from [GenericClass](genericclass.md).[constructor](genericclass.md#markdown-header-constructor)*
 
-*Defined in [classes.ts:284](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-284)*
+*Defined in [classes.ts:293](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-293)*
 
 Constructor short text.
 
@@ -64,7 +64,7 @@ ___
 
 *Inherited from [GenericClass](genericclass.md).[p2](genericclass.md#markdown-header-protected-p2)*
 
-*Defined in [classes.ts:295](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-295)*
+*Defined in [classes.ts:304](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-304)*
 
 Private string property
 
@@ -76,7 +76,7 @@ ___
 
 *Inherited from [GenericClass](genericclass.md).[p3](genericclass.md#markdown-header-p3)*
 
-*Defined in [classes.ts:295](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-295)*
+*Defined in [classes.ts:304](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-304)*
 
 Public number property
 
@@ -88,7 +88,7 @@ ___
 
 *Inherited from [GenericClass](genericclass.md).[p5](genericclass.md#markdown-header-p5)*
 
-*Defined in [classes.ts:295](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-295)*
+*Defined in [classes.ts:304](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-304)*
 
 Readonly property
 
@@ -100,7 +100,7 @@ ___
 
 *Inherited from [GenericClass](genericclass.md).[value](genericclass.md#markdown-header-value)*
 
-*Defined in [classes.ts:284](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-284)*
+*Defined in [classes.ts:293](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-293)*
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 *Inherited from [GenericClass](genericclass.md).[getValue](genericclass.md#markdown-header-getvalue)*
 
-*Defined in [classes.ts:305](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-305)*
+*Defined in [classes.ts:314](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-314)*
 
 **Returns:** [SubClassB](subclassb.md)
 
@@ -124,7 +124,7 @@ ___
 
 *Inherited from [GenericClass](genericclass.md).[setValue](genericclass.md#markdown-header-setvalue)*
 
-*Defined in [classes.ts:301](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-301)*
+*Defined in [classes.ts:310](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-310)*
 
 **Parameters:**
 

--- a/test/fixtures/bitbucket/classes/subclassa.md
+++ b/test/fixtures/bitbucket/classes/subclassa.md
@@ -66,7 +66,7 @@ This class has no own constructor, so its constructor should be inherited from B
 
 | Param | Type |
 | ------ | ------ |
-| name | `string` | 
+| name | `string` |
 
 **Returns:** [SubClassA](subclassa.md)
 
@@ -78,7 +78,7 @@ This class has no own constructor, so its constructor should be inherited from B
 
 | Param | Type |
 | ------ | ------ |
-| source | [BaseClass](baseclass.md) | 
+| source | [BaseClass](baseclass.md) |
 
 **Returns:** [SubClassA](subclassa.md)
 
@@ -262,7 +262,7 @@ This is a simple interface function.
 
 | Param | Type |
 | ------ | ------ |
-| value | `string` | 
+| value | `string` |
 
 **Returns:** `void`
 
@@ -318,10 +318,10 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| originalValues | [BaseClass](baseclass.md) | 
-| newRecord | `any` | 
-| fieldNames | `string`[] | 
-| mandatoryFields | `string`[] | 
+| originalValues | [BaseClass](baseclass.md) |
+| newRecord | `any` |
+| fieldNames | `string`[] |
+| mandatoryFields | `string`[] |
 
 **Returns:** `string`
 

--- a/test/fixtures/bitbucket/classes/subclassb.md
+++ b/test/fixtures/bitbucket/classes/subclassb.md
@@ -33,6 +33,7 @@ The constructor of the original class should be overwritten.
 
 * [abstractMethod](subclassb.md#markdown-header-abstractmethod)
 * [arrowFunction](subclassb.md#markdown-header-arrowfunction)
+* [doOtherThings](subclassb.md#markdown-header-dootherthings)
 * [doSomething](subclassb.md#markdown-header-dosomething)
 * [getName](subclassb.md#markdown-header-getname)
 * [setName](subclassb.md#markdown-header-setname)
@@ -56,7 +57,7 @@ The constructor of the original class should be overwritten.
 
 | Param | Type |
 | ------ | ------ |
-| name | `string` | 
+| name | `string` |
 
 **Returns:** [SubClassB](subclassb.md)
 
@@ -147,6 +148,25 @@ This is a simple fat arrow function.
 
 ___
 
+###  doOtherThings
+
+▸ **doOtherThings**(value: * `string` &#124; `number` &#124; [SubClassA](subclassa.md)*, secondValue?: *[SubClassA](subclassa.md)*): `void`
+
+*Defined in [classes.ts:282](https://bitbucket.org/owner/repository_name/src/master/src/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-282)*
+
+Description for doOtherThings.
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| value |  `string` &#124; `number` &#124; [SubClassA](subclassa.md)|  Description for value |
+| `Optional` secondValue | [SubClassA](subclassa.md) |  Description for optional value |
+
+**Returns:** `void`
+
+___
+
 ###  doSomething
 
 ▸ **doSomething**(value: *[`string`, [SubClassA](subclassa.md), [SubClassB](subclassb.md)]*): `void`
@@ -157,7 +177,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| value | [`string`, [SubClassA](subclassa.md), [SubClassB](subclassb.md)] | 
+| value | [`string`, [SubClassA](subclassa.md), [SubClassB](subclassb.md)] |
 
 **Returns:** `void`
 
@@ -218,10 +238,10 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| originalValues | [BaseClass](baseclass.md) | 
-| newRecord | `any` | 
-| fieldNames | `string`[] | 
-| mandatoryFields | `string`[] | 
+| originalValues | [BaseClass](baseclass.md) |
+| newRecord | `any` |
+| fieldNames | `string`[] |
+| mandatoryFields | `string`[] |
 
 **Returns:** `string`
 

--- a/test/fixtures/bitbucket/classes/vector.md
+++ b/test/fixtures/bitbucket/classes/vector.md
@@ -42,9 +42,9 @@
 
 | Param | Type |
 | ------ | ------ |
-| x | `number` | 
-| y | `number` | 
-| z | `number` | 
+| x | `number` |
+| y | `number` |
+| z | `number` |
 
 **Returns:** [Vector](vector.md)
 
@@ -88,8 +88,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Vector](vector.md) | 
-| v2 | [Vector](vector.md) | 
+| v1 | [Vector](vector.md) |
+| v2 | [Vector](vector.md) |
 
 **Returns:** [Vector](vector.md)
 
@@ -105,8 +105,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Vector](vector.md) | 
-| v2 | [Vector](vector.md) | 
+| v1 | [Vector](vector.md) |
+| v2 | [Vector](vector.md) |
 
 **Returns:** `number`
 
@@ -122,7 +122,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v | [Vector](vector.md) | 
+| v | [Vector](vector.md) |
 
 **Returns:** `number`
 
@@ -138,8 +138,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Vector](vector.md) | 
-| v2 | [Vector](vector.md) | 
+| v1 | [Vector](vector.md) |
+| v2 | [Vector](vector.md) |
 
 **Returns:** [Vector](vector.md)
 
@@ -155,7 +155,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v | [Vector](vector.md) | 
+| v | [Vector](vector.md) |
 
 **Returns:** [Vector](vector.md)
 
@@ -171,8 +171,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Vector](vector.md) | 
-| v2 | [Vector](vector.md) | 
+| v1 | [Vector](vector.md) |
+| v2 | [Vector](vector.md) |
 
 **Returns:** [Vector](vector.md)
 
@@ -188,8 +188,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| k | `number` | 
-| v | [Vector](vector.md) | 
+| k | `number` |
+| v | [Vector](vector.md) |
 
 **Returns:** [Vector](vector.md)
 

--- a/test/fixtures/bitbucket/interfaces/interfaces.clockconstructor.md
+++ b/test/fixtures/bitbucket/interfaces/interfaces.clockconstructor.md
@@ -26,8 +26,8 @@
 
 | Param | Type |
 | ------ | ------ |
-| hour | `number` | 
-| minute | `number` | 
+| hour | `number` |
+| minute | `number` |
 
 **Returns:** [ClockInterface](interfaces.clockinterface.md)
 

--- a/test/fixtures/bitbucket/interfaces/interfaces.clockinterface.md
+++ b/test/fixtures/bitbucket/interfaces/interfaces.clockinterface.md
@@ -41,7 +41,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| d | `Date` | 
+| d | `Date` |
 
 **Returns:** `any`
 

--- a/test/fixtures/bitbucket/interfaces/interfaces.surface.md
+++ b/test/fixtures/bitbucket/interfaces/interfaces.surface.md
@@ -32,7 +32,7 @@
 
 | Param | Type |
 | ------ | ------ |
-| pos | [Vector](../classes/vector.md) | 
+| pos | [Vector](../classes/vector.md) |
 
 **Returns:** [Color](../classes/color.md)
 
@@ -51,7 +51,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| pos | [Vector](../classes/vector.md) | 
+| pos | [Vector](../classes/vector.md) |
 
 **Returns:** `number`
 
@@ -78,7 +78,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| pos | [Vector](../classes/vector.md) | 
+| pos | [Vector](../classes/vector.md) |
 
 **Returns:** [Color](../classes/color.md)
 

--- a/test/fixtures/bitbucket/interfaces/iprintinterface.md
+++ b/test/fixtures/bitbucket/interfaces/iprintinterface.md
@@ -34,7 +34,7 @@ It should be inherited by all subinterfaces.
 
 | Param | Type |
 | ------ | ------ |
-| value | `string` | 
+| value | `string` |
 
 **Returns:** `void`
 

--- a/test/fixtures/bitbucket/interfaces/iprintnameinterface.md
+++ b/test/fixtures/bitbucket/interfaces/iprintnameinterface.md
@@ -80,7 +80,7 @@ It should be inherited by all subinterfaces.
 
 | Param | Type |
 | ------ | ------ |
-| value | `string` | 
+| value | `string` |
 
 **Returns:** `void`
 

--- a/test/fixtures/bitbucket/modules/interfaces.md
+++ b/test/fixtures/bitbucket/modules/interfaces.md
@@ -44,8 +44,8 @@
 
 | Param | Type |
 | ------ | ------ |
-| source | `string` | 
-| subString | `string` | 
+| source | `string` |
+| subString | `string` |
 
 **Returns:** `boolean`
 
@@ -81,9 +81,9 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| ctor | [ClockConstructor](../interfaces/interfaces.clockconstructor.md) | 
-| hour | `number` | 
-| minute | `number` | 
+| ctor | [ClockConstructor](../interfaces/interfaces.clockconstructor.md) |
+| hour | `number` |
+| minute | `number` |
 
 **Returns:** [ClockInterface](../interfaces/interfaces.clockinterface.md)
 

--- a/test/fixtures/gitbook/classes/_classes_.baseclass.md
+++ b/test/fixtures/gitbook/classes/_classes_.baseclass.md
@@ -34,7 +34,7 @@ This is a simple example on how to use BaseClass.
 
 | Param | Type |
 | ------ | ------ |
-| name | `string` | 
+| name | `string` |
 
 **Returns:** [BaseClass](_classes_.baseclass.md)
 
@@ -44,7 +44,7 @@ This is a simple example on how to use BaseClass.
 
 | Param | Type |
 | ------ | ------ |
-| source | [BaseClass](_classes_.baseclass.md) | 
+| source | [BaseClass](_classes_.baseclass.md) |
 
 **Returns:** [BaseClass](_classes_.baseclass.md)
 
@@ -209,10 +209,10 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| originalValues | [BaseClass](_classes_.baseclass.md) | 
-| newRecord | `any` | 
-| fieldNames | `string`[] | 
-| mandatoryFields | `string`[] | 
+| originalValues | [BaseClass](_classes_.baseclass.md) |
+| newRecord | `any` |
+| fieldNames | `string`[] |
+| mandatoryFields | `string`[] |
 
 **Returns:** `string`
 

--- a/test/fixtures/gitbook/classes/_classes_.genericclass.md
+++ b/test/fixtures/gitbook/classes/_classes_.genericclass.md
@@ -21,7 +21,7 @@ This a type parameter.
 
 ⊕ **new GenericClass**(p1: *`any`*, p2: *`T`*, p3: *`number`*, p4: *`number`*, p5: *`string`*): [GenericClass](_classes_.genericclass.md)
 
-*Defined in [classes.ts:284](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L284)*
+*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 Constructor short text.
 
@@ -47,7 +47,7 @@ ___
 
 **● p2**: *`T`*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Private string property
 
@@ -58,7 +58,7 @@ ___
 
 **● p3**: *`number`*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Public number property
 
@@ -69,7 +69,7 @@ ___
 
 **● p4**: *`number`*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Public implicit any property
 
@@ -80,7 +80,7 @@ ___
 
 **● p5**: *`string`*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Readonly property
 
@@ -91,7 +91,7 @@ ___
 
 **● value**: *`T`*
 
-*Defined in [classes.ts:284](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L284)*
+*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 ▸ **getValue**(): `T`
 
-*Defined in [classes.ts:305](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L305)*
+*Defined in [classes.ts:314](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L314)*
 
 **Returns:** `T`
 
@@ -114,7 +114,7 @@ ___
 
 ▸ **setValue**(value: *`T`*): `void`
 
-*Defined in [classes.ts:301](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L301)*
+*Defined in [classes.ts:310](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L310)*
 
 **Parameters:**
 

--- a/test/fixtures/gitbook/classes/_classes_.internalclass.md
+++ b/test/fixtures/gitbook/classes/_classes_.internalclass.md
@@ -22,7 +22,7 @@ This is an internal class, it is not exported.
 
 | Param | Type |
 | ------ | ------ |
-| options | `object` | 
+| options | `object` |
 
 **Returns:** [InternalClass](_classes_.internalclass.md)
 

--- a/test/fixtures/gitbook/classes/_classes_.nongenericclass.md
+++ b/test/fixtures/gitbook/classes/_classes_.nongenericclass.md
@@ -18,7 +18,7 @@ This a non generic class derived from a [generic class](_classes_.genericclass.m
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[constructor](_classes_.genericclass.md#constructor)*
 
-*Defined in [classes.ts:284](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L284)*
+*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 Constructor short text.
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[p2](_classes_.genericclass.md#p2)*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Private string property
 
@@ -59,7 +59,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[p3](_classes_.genericclass.md#p3)*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Public number property
 
@@ -72,7 +72,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[p5](_classes_.genericclass.md#p5)*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Readonly property
 
@@ -85,7 +85,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[value](_classes_.genericclass.md#value)*
 
-*Defined in [classes.ts:284](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L284)*
+*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[getValue](_classes_.genericclass.md#getvalue)*
 
-*Defined in [classes.ts:305](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L305)*
+*Defined in [classes.ts:314](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L314)*
 
 **Returns:** [SubClassB](_classes_.subclassb.md)
 
@@ -112,7 +112,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[setValue](_classes_.genericclass.md#setvalue)*
 
-*Defined in [classes.ts:301](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L301)*
+*Defined in [classes.ts:310](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L310)*
 
 **Parameters:**
 

--- a/test/fixtures/gitbook/classes/_classes_.subclassa.md
+++ b/test/fixtures/gitbook/classes/_classes_.subclassa.md
@@ -33,7 +33,7 @@ This class has no own constructor, so its constructor should be inherited from B
 
 | Param | Type |
 | ------ | ------ |
-| name | `string` | 
+| name | `string` |
 
 **Returns:** [SubClassA](_classes_.subclassa.md)
 
@@ -45,7 +45,7 @@ This class has no own constructor, so its constructor should be inherited from B
 
 | Param | Type |
 | ------ | ------ |
-| source | [BaseClass](_classes_.baseclass.md) | 
+| source | [BaseClass](_classes_.baseclass.md) |
 
 **Returns:** [SubClassA](_classes_.subclassa.md)
 
@@ -243,7 +243,7 @@ This is a simple interface function.
 
 | Param | Type |
 | ------ | ------ |
-| value | `string` | 
+| value | `string` |
 
 **Returns:** `void`
 
@@ -302,10 +302,10 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| originalValues | [BaseClass](_classes_.baseclass.md) | 
-| newRecord | `any` | 
-| fieldNames | `string`[] | 
-| mandatoryFields | `string`[] | 
+| originalValues | [BaseClass](_classes_.baseclass.md) |
+| newRecord | `any` |
+| fieldNames | `string`[] |
+| mandatoryFields | `string`[] |
 
 **Returns:** `string`
 

--- a/test/fixtures/gitbook/classes/_classes_.subclassb.md
+++ b/test/fixtures/gitbook/classes/_classes_.subclassb.md
@@ -30,7 +30,7 @@ The constructor of the original class should be overwritten.
 
 | Param | Type |
 | ------ | ------ |
-| name | `string` | 
+| name | `string` |
 
 **Returns:** [SubClassB](_classes_.subclassb.md)
 
@@ -128,6 +128,26 @@ This is a simple fat arrow function.
 **Returns:** `void`
 
 ___
+<a id="dootherthings"></a>
+
+##  doOtherThings
+
+▸ **doOtherThings**(value: * `string` &#124; `number` &#124; [SubClassA](_classes_.subclassa.md)*, secondValue?: *[SubClassA](_classes_.subclassa.md)*): `void`
+
+*Defined in [classes.ts:282](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L282)*
+
+Description for doOtherThings.
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| value |  `string` &#124; `number` &#124; [SubClassA](_classes_.subclassa.md)|  Description for value |
+| `Optional` secondValue | [SubClassA](_classes_.subclassa.md) |  Description for optional value |
+
+**Returns:** `void`
+
+___
 <a id="dosomething"></a>
 
 ##  doSomething
@@ -140,7 +160,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| value | [`string`, [SubClassA](_classes_.subclassa.md), [SubClassB](_classes_.subclassb.md)] | 
+| value | [`string`, [SubClassA](_classes_.subclassa.md), [SubClassB](_classes_.subclassb.md)] |
 
 **Returns:** `void`
 
@@ -204,10 +224,10 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| originalValues | [BaseClass](_classes_.baseclass.md) | 
-| newRecord | `any` | 
-| fieldNames | `string`[] | 
-| mandatoryFields | `string`[] | 
+| originalValues | [BaseClass](_classes_.baseclass.md) |
+| newRecord | `any` |
+| fieldNames | `string`[] |
+| mandatoryFields | `string`[] |
 
 **Returns:** `string`
 

--- a/test/fixtures/gitbook/classes/_generics_.mythirdclass.md
+++ b/test/fixtures/gitbook/classes/_generics_.mythirdclass.md
@@ -18,7 +18,7 @@
 
 | Param | Type |
 | ------ | ------ |
-| arg | [MyFourthClass](_generics_.myfourthclass.md)<[MyFirstClass](_generics_.myfirstclass.md), [MySecondClass](_generics_.mysecondclass.md)<[MyFirstClass](_generics_.myfirstclass.md)>> | 
+| arg | [MyFourthClass](_generics_.myfourthclass.md)<[MyFirstClass](_generics_.myfirstclass.md), [MySecondClass](_generics_.mysecondclass.md)<[MyFirstClass](_generics_.myfirstclass.md)>> |
 
 **Returns:** [MyThirdClass](_generics_.mythirdclass.md)
 

--- a/test/fixtures/gitbook/classes/_interfaces_.color.md
+++ b/test/fixtures/gitbook/classes/_interfaces_.color.md
@@ -18,9 +18,9 @@
 
 | Param | Type |
 | ------ | ------ |
-| r | `number` | 
-| g | `number` | 
-| b | `number` | 
+| r | `number` |
+| g | `number` |
+| b | `number` |
 
 **Returns:** [Color](_interfaces_.color.md)
 
@@ -115,8 +115,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Color](_interfaces_.color.md) | 
-| v2 | [Color](_interfaces_.color.md) | 
+| v1 | [Color](_interfaces_.color.md) |
+| v2 | [Color](_interfaces_.color.md) |
 
 **Returns:** [Color](_interfaces_.color.md)
 
@@ -133,8 +133,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| k | `number` | 
-| v | [Color](_interfaces_.color.md) | 
+| k | `number` |
+| v | [Color](_interfaces_.color.md) |
 
 **Returns:** [Color](_interfaces_.color.md)
 
@@ -151,8 +151,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Color](_interfaces_.color.md) | 
-| v2 | [Color](_interfaces_.color.md) | 
+| v1 | [Color](_interfaces_.color.md) |
+| v2 | [Color](_interfaces_.color.md) |
 
 **Returns:** [Color](_interfaces_.color.md)
 
@@ -169,7 +169,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| c | [Color](_interfaces_.color.md) | 
+| c | [Color](_interfaces_.color.md) |
 
 **Returns:** `object`
 

--- a/test/fixtures/gitbook/classes/_interfaces_.vector.md
+++ b/test/fixtures/gitbook/classes/_interfaces_.vector.md
@@ -18,9 +18,9 @@
 
 | Param | Type |
 | ------ | ------ |
-| x | `number` | 
-| y | `number` | 
-| z | `number` | 
+| x | `number` |
+| y | `number` |
+| z | `number` |
 
 **Returns:** [Vector](_interfaces_.vector.md)
 
@@ -70,8 +70,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Vector](_interfaces_.vector.md) | 
-| v2 | [Vector](_interfaces_.vector.md) | 
+| v1 | [Vector](_interfaces_.vector.md) |
+| v2 | [Vector](_interfaces_.vector.md) |
 
 **Returns:** [Vector](_interfaces_.vector.md)
 
@@ -88,8 +88,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Vector](_interfaces_.vector.md) | 
-| v2 | [Vector](_interfaces_.vector.md) | 
+| v1 | [Vector](_interfaces_.vector.md) |
+| v2 | [Vector](_interfaces_.vector.md) |
 
 **Returns:** `number`
 
@@ -106,7 +106,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v | [Vector](_interfaces_.vector.md) | 
+| v | [Vector](_interfaces_.vector.md) |
 
 **Returns:** `number`
 
@@ -123,8 +123,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Vector](_interfaces_.vector.md) | 
-| v2 | [Vector](_interfaces_.vector.md) | 
+| v1 | [Vector](_interfaces_.vector.md) |
+| v2 | [Vector](_interfaces_.vector.md) |
 
 **Returns:** [Vector](_interfaces_.vector.md)
 
@@ -141,7 +141,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v | [Vector](_interfaces_.vector.md) | 
+| v | [Vector](_interfaces_.vector.md) |
 
 **Returns:** [Vector](_interfaces_.vector.md)
 
@@ -158,8 +158,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Vector](_interfaces_.vector.md) | 
-| v2 | [Vector](_interfaces_.vector.md) | 
+| v1 | [Vector](_interfaces_.vector.md) |
+| v2 | [Vector](_interfaces_.vector.md) |
 
 **Returns:** [Vector](_interfaces_.vector.md)
 
@@ -176,8 +176,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| k | `number` | 
-| v | [Vector](_interfaces_.vector.md) | 
+| k | `number` |
+| v | [Vector](_interfaces_.vector.md) |
 
 **Returns:** [Vector](_interfaces_.vector.md)
 

--- a/test/fixtures/gitbook/interfaces/_classes_.iprintinterface.md
+++ b/test/fixtures/gitbook/interfaces/_classes_.iprintinterface.md
@@ -26,7 +26,7 @@ It should be inherited by all subinterfaces.
 
 | Param | Type |
 | ------ | ------ |
-| value | `string` | 
+| value | `string` |
 
 **Returns:** `void`
 

--- a/test/fixtures/gitbook/interfaces/_classes_.iprintnameinterface.md
+++ b/test/fixtures/gitbook/interfaces/_classes_.iprintnameinterface.md
@@ -69,7 +69,7 @@ It should be inherited by all subinterfaces.
 
 | Param | Type |
 | ------ | ------ |
-| value | `string` | 
+| value | `string` |
 
 **Returns:** `void`
 

--- a/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.clockconstructor.md
+++ b/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.clockconstructor.md
@@ -18,8 +18,8 @@
 
 | Param | Type |
 | ------ | ------ |
-| hour | `number` | 
-| minute | `number` | 
+| hour | `number` |
+| minute | `number` |
 
 **Returns:** [ClockInterface](_interfaces_.interfaces.clockinterface.md)
 

--- a/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.clockinterface.md
+++ b/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.clockinterface.md
@@ -30,7 +30,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| d | `Date` | 
+| d | `Date` |
 
 **Returns:** `any`
 

--- a/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.surface.md
+++ b/test/fixtures/gitbook/interfaces/_interfaces_.interfaces.surface.md
@@ -21,7 +21,7 @@
 
 | Param | Type |
 | ------ | ------ |
-| pos | [Vector](../classes/_interfaces_.vector.md) | 
+| pos | [Vector](../classes/_interfaces_.vector.md) |
 
 **Returns:** [Color](../classes/_interfaces_.color.md)
 
@@ -41,7 +41,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| pos | [Vector](../classes/_interfaces_.vector.md) | 
+| pos | [Vector](../classes/_interfaces_.vector.md) |
 
 **Returns:** `number`
 
@@ -70,7 +70,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| pos | [Vector](../classes/_interfaces_.vector.md) | 
+| pos | [Vector](../classes/_interfaces_.vector.md) |
 
 **Returns:** [Color](../classes/_interfaces_.color.md)
 

--- a/test/fixtures/gitbook/modules/_functions_.md
+++ b/test/fixtures/gitbook/modules/_functions_.md
@@ -63,11 +63,11 @@ This is a function with a parameter that has a default value.
 
 | Param | Type | Default value |
 | ------ | ------ | ------ |
-| `Default value` valueA | `string` | &quot;defaultValue&quot; | 
-| `Default value` valueB | `number` | 100 | 
-| `Default value` valueC | `number` |  Number.NaN | 
-| `Default value` valueD | `boolean` | true | 
-| `Default value` valueE | `boolean` | false | 
+| `Default value` valueA | `string` | &quot;defaultValue&quot; |
+| `Default value` valueB | `number` | 100 |
+| `Default value` valueC | `number` |  Number.NaN |
+| `Default value` valueD | `boolean` | true |
+| `Default value` valueE | `boolean` | false |
 
 **Returns:** `string`
 The input value or the default value.

--- a/test/fixtures/gitbook/modules/_interfaces_.interfaces.md
+++ b/test/fixtures/gitbook/modules/_interfaces_.interfaces.md
@@ -44,8 +44,8 @@
 
 | Param | Type |
 | ------ | ------ |
-| source | `string` | 
-| subString | `string` | 
+| source | `string` |
+| subString | `string` |
 
 **Returns:** `boolean`
 
@@ -86,9 +86,9 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| ctor | [ClockConstructor](../interfaces/_interfaces_.interfaces.clockconstructor.md) | 
-| hour | `number` | 
-| minute | `number` | 
+| ctor | [ClockConstructor](../interfaces/_interfaces_.interfaces.clockconstructor.md) |
+| hour | `number` |
+| minute | `number` |
 
 **Returns:** [ClockInterface](../interfaces/_interfaces_.interfaces.clockinterface.md)
 

--- a/test/fixtures/github/classes/_classes_.baseclass.md
+++ b/test/fixtures/github/classes/_classes_.baseclass.md
@@ -63,7 +63,7 @@ This is a simple example on how to use BaseClass.
 
 | Param | Type |
 | ------ | ------ |
-| name | `string` | 
+| name | `string` |
 
 **Returns:** [BaseClass](_classes_.baseclass.md)
 
@@ -73,7 +73,7 @@ This is a simple example on how to use BaseClass.
 
 | Param | Type |
 | ------ | ------ |
-| source | [BaseClass](_classes_.baseclass.md) | 
+| source | [BaseClass](_classes_.baseclass.md) |
 
 **Returns:** [BaseClass](_classes_.baseclass.md)
 
@@ -238,10 +238,10 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| originalValues | [BaseClass](_classes_.baseclass.md) | 
-| newRecord | `any` | 
-| fieldNames | `string`[] | 
-| mandatoryFields | `string`[] | 
+| originalValues | [BaseClass](_classes_.baseclass.md) |
+| newRecord | `any` |
+| fieldNames | `string`[] |
+| mandatoryFields | `string`[] |
 
 **Returns:** `string`
 

--- a/test/fixtures/github/classes/_classes_.genericclass.md
+++ b/test/fixtures/github/classes/_classes_.genericclass.md
@@ -44,7 +44,7 @@ This a type parameter.
 
 ⊕ **new GenericClass**(p1: *`any`*, p2: *`T`*, p3: *`number`*, p4: *`number`*, p5: *`string`*): [GenericClass](_classes_.genericclass.md)
 
-*Defined in [classes.ts:284](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L284)*
+*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 Constructor short text.
 
@@ -70,7 +70,7 @@ ___
 
 **● p2**: *`T`*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Private string property
 
@@ -81,7 +81,7 @@ ___
 
 **● p3**: *`number`*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Public number property
 
@@ -92,7 +92,7 @@ ___
 
 **● p4**: *`number`*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Public implicit any property
 
@@ -103,7 +103,7 @@ ___
 
 **● p5**: *`string`*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Readonly property
 
@@ -114,7 +114,7 @@ ___
 
 **● value**: *`T`*
 
-*Defined in [classes.ts:284](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L284)*
+*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 ___
 
@@ -126,7 +126,7 @@ ___
 
 ▸ **getValue**(): `T`
 
-*Defined in [classes.ts:305](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L305)*
+*Defined in [classes.ts:314](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L314)*
 
 **Returns:** `T`
 
@@ -137,7 +137,7 @@ ___
 
 ▸ **setValue**(value: *`T`*): `void`
 
-*Defined in [classes.ts:301](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L301)*
+*Defined in [classes.ts:310](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L310)*
 
 **Parameters:**
 

--- a/test/fixtures/github/classes/_classes_.internalclass.md
+++ b/test/fixtures/github/classes/_classes_.internalclass.md
@@ -32,7 +32,7 @@ This is an internal class, it is not exported.
 
 | Param | Type |
 | ------ | ------ |
-| options | `object` | 
+| options | `object` |
 
 **Returns:** [InternalClass](_classes_.internalclass.md)
 

--- a/test/fixtures/github/classes/_classes_.nongenericclass.md
+++ b/test/fixtures/github/classes/_classes_.nongenericclass.md
@@ -40,7 +40,7 @@ This a non generic class derived from a [generic class](_classes_.genericclass.m
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[constructor](_classes_.genericclass.md#constructor)*
 
-*Defined in [classes.ts:284](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L284)*
+*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 Constructor short text.
 
@@ -68,7 +68,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[p2](_classes_.genericclass.md#p2)*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Private string property
 
@@ -81,7 +81,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[p3](_classes_.genericclass.md#p3)*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Public number property
 
@@ -94,7 +94,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[p5](_classes_.genericclass.md#p5)*
 
-*Defined in [classes.ts:295](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L295)*
+*Defined in [classes.ts:304](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L304)*
 
 Readonly property
 
@@ -107,7 +107,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[value](_classes_.genericclass.md#value)*
 
-*Defined in [classes.ts:284](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L284)*
+*Defined in [classes.ts:293](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L293)*
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[getValue](_classes_.genericclass.md#getvalue)*
 
-*Defined in [classes.ts:305](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L305)*
+*Defined in [classes.ts:314](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L314)*
 
 **Returns:** [SubClassB](_classes_.subclassb.md)
 
@@ -134,7 +134,7 @@ ___
 
 *Inherited from [GenericClass](_classes_.genericclass.md).[setValue](_classes_.genericclass.md#setvalue)*
 
-*Defined in [classes.ts:301](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L301)*
+*Defined in [classes.ts:310](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L310)*
 
 **Parameters:**
 

--- a/test/fixtures/github/classes/_classes_.subclassa.md
+++ b/test/fixtures/github/classes/_classes_.subclassa.md
@@ -68,7 +68,7 @@ This class has no own constructor, so its constructor should be inherited from B
 
 | Param | Type |
 | ------ | ------ |
-| name | `string` | 
+| name | `string` |
 
 **Returns:** [SubClassA](_classes_.subclassa.md)
 
@@ -80,7 +80,7 @@ This class has no own constructor, so its constructor should be inherited from B
 
 | Param | Type |
 | ------ | ------ |
-| source | [BaseClass](_classes_.baseclass.md) | 
+| source | [BaseClass](_classes_.baseclass.md) |
 
 **Returns:** [SubClassA](_classes_.subclassa.md)
 
@@ -278,7 +278,7 @@ This is a simple interface function.
 
 | Param | Type |
 | ------ | ------ |
-| value | `string` | 
+| value | `string` |
 
 **Returns:** `void`
 
@@ -337,10 +337,10 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| originalValues | [BaseClass](_classes_.baseclass.md) | 
-| newRecord | `any` | 
-| fieldNames | `string`[] | 
-| mandatoryFields | `string`[] | 
+| originalValues | [BaseClass](_classes_.baseclass.md) |
+| newRecord | `any` |
+| fieldNames | `string`[] |
+| mandatoryFields | `string`[] |
 
 **Returns:** `string`
 

--- a/test/fixtures/github/classes/_classes_.subclassb.md
+++ b/test/fixtures/github/classes/_classes_.subclassb.md
@@ -33,6 +33,7 @@ The constructor of the original class should be overwritten.
 
 * [abstractMethod](_classes_.subclassb.md#abstractmethod)
 * [arrowFunction](_classes_.subclassb.md#arrowfunction)
+* [doOtherThings](_classes_.subclassb.md#dootherthings)
 * [doSomething](_classes_.subclassb.md#dosomething)
 * [getName](_classes_.subclassb.md#getname)
 * [setName](_classes_.subclassb.md#setname)
@@ -58,7 +59,7 @@ The constructor of the original class should be overwritten.
 
 | Param | Type |
 | ------ | ------ |
-| name | `string` | 
+| name | `string` |
 
 **Returns:** [SubClassB](_classes_.subclassb.md)
 
@@ -156,6 +157,26 @@ This is a simple fat arrow function.
 **Returns:** `void`
 
 ___
+<a id="dootherthings"></a>
+
+###  doOtherThings
+
+▸ **doOtherThings**(value: * `string` &#124; `number` &#124; [SubClassA](_classes_.subclassa.md)*, secondValue?: *[SubClassA](_classes_.subclassa.md)*): `void`
+
+*Defined in [classes.ts:282](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L282)*
+
+Description for doOtherThings.
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| value |  `string` &#124; `number` &#124; [SubClassA](_classes_.subclassa.md)|  Description for value |
+| `Optional` secondValue | [SubClassA](_classes_.subclassa.md) |  Description for optional value |
+
+**Returns:** `void`
+
+___
 <a id="dosomething"></a>
 
 ###  doSomething
@@ -168,7 +189,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| value | [`string`, [SubClassA](_classes_.subclassa.md), [SubClassB](_classes_.subclassb.md)] | 
+| value | [`string`, [SubClassA](_classes_.subclassa.md), [SubClassB](_classes_.subclassb.md)] |
 
 **Returns:** `void`
 
@@ -232,10 +253,10 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| originalValues | [BaseClass](_classes_.baseclass.md) | 
-| newRecord | `any` | 
-| fieldNames | `string`[] | 
-| mandatoryFields | `string`[] | 
+| originalValues | [BaseClass](_classes_.baseclass.md) |
+| newRecord | `any` |
+| fieldNames | `string`[] |
+| mandatoryFields | `string`[] |
 
 **Returns:** `string`
 

--- a/test/fixtures/github/classes/_generics_.mythirdclass.md
+++ b/test/fixtures/github/classes/_generics_.mythirdclass.md
@@ -32,7 +32,7 @@
 
 | Param | Type |
 | ------ | ------ |
-| arg | [MyFourthClass](_generics_.myfourthclass.md)<[MyFirstClass](_generics_.myfirstclass.md), [MySecondClass](_generics_.mysecondclass.md)<[MyFirstClass](_generics_.myfirstclass.md)>> | 
+| arg | [MyFourthClass](_generics_.myfourthclass.md)<[MyFirstClass](_generics_.myfirstclass.md), [MySecondClass](_generics_.mysecondclass.md)<[MyFirstClass](_generics_.myfirstclass.md)>> |
 
 **Returns:** [MyThirdClass](_generics_.mythirdclass.md)
 

--- a/test/fixtures/github/classes/_interfaces_.color.md
+++ b/test/fixtures/github/classes/_interfaces_.color.md
@@ -46,9 +46,9 @@
 
 | Param | Type |
 | ------ | ------ |
-| r | `number` | 
-| g | `number` | 
-| b | `number` | 
+| r | `number` |
+| g | `number` |
+| b | `number` |
 
 **Returns:** [Color](_interfaces_.color.md)
 
@@ -143,8 +143,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Color](_interfaces_.color.md) | 
-| v2 | [Color](_interfaces_.color.md) | 
+| v1 | [Color](_interfaces_.color.md) |
+| v2 | [Color](_interfaces_.color.md) |
 
 **Returns:** [Color](_interfaces_.color.md)
 
@@ -161,8 +161,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| k | `number` | 
-| v | [Color](_interfaces_.color.md) | 
+| k | `number` |
+| v | [Color](_interfaces_.color.md) |
 
 **Returns:** [Color](_interfaces_.color.md)
 
@@ -179,8 +179,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Color](_interfaces_.color.md) | 
-| v2 | [Color](_interfaces_.color.md) | 
+| v1 | [Color](_interfaces_.color.md) |
+| v2 | [Color](_interfaces_.color.md) |
 
 **Returns:** [Color](_interfaces_.color.md)
 
@@ -197,7 +197,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| c | [Color](_interfaces_.color.md) | 
+| c | [Color](_interfaces_.color.md) |
 
 **Returns:** `object`
 

--- a/test/fixtures/github/classes/_interfaces_.vector.md
+++ b/test/fixtures/github/classes/_interfaces_.vector.md
@@ -44,9 +44,9 @@
 
 | Param | Type |
 | ------ | ------ |
-| x | `number` | 
-| y | `number` | 
-| z | `number` | 
+| x | `number` |
+| y | `number` |
+| z | `number` |
 
 **Returns:** [Vector](_interfaces_.vector.md)
 
@@ -96,8 +96,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Vector](_interfaces_.vector.md) | 
-| v2 | [Vector](_interfaces_.vector.md) | 
+| v1 | [Vector](_interfaces_.vector.md) |
+| v2 | [Vector](_interfaces_.vector.md) |
 
 **Returns:** [Vector](_interfaces_.vector.md)
 
@@ -114,8 +114,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Vector](_interfaces_.vector.md) | 
-| v2 | [Vector](_interfaces_.vector.md) | 
+| v1 | [Vector](_interfaces_.vector.md) |
+| v2 | [Vector](_interfaces_.vector.md) |
 
 **Returns:** `number`
 
@@ -132,7 +132,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v | [Vector](_interfaces_.vector.md) | 
+| v | [Vector](_interfaces_.vector.md) |
 
 **Returns:** `number`
 
@@ -149,8 +149,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Vector](_interfaces_.vector.md) | 
-| v2 | [Vector](_interfaces_.vector.md) | 
+| v1 | [Vector](_interfaces_.vector.md) |
+| v2 | [Vector](_interfaces_.vector.md) |
 
 **Returns:** [Vector](_interfaces_.vector.md)
 
@@ -167,7 +167,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v | [Vector](_interfaces_.vector.md) | 
+| v | [Vector](_interfaces_.vector.md) |
 
 **Returns:** [Vector](_interfaces_.vector.md)
 
@@ -184,8 +184,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| v1 | [Vector](_interfaces_.vector.md) | 
-| v2 | [Vector](_interfaces_.vector.md) | 
+| v1 | [Vector](_interfaces_.vector.md) |
+| v2 | [Vector](_interfaces_.vector.md) |
 
 **Returns:** [Vector](_interfaces_.vector.md)
 
@@ -202,8 +202,8 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| k | `number` | 
-| v | [Vector](_interfaces_.vector.md) | 
+| k | `number` |
+| v | [Vector](_interfaces_.vector.md) |
 
 **Returns:** [Vector](_interfaces_.vector.md)
 

--- a/test/fixtures/github/interfaces/_classes_.iprintinterface.md
+++ b/test/fixtures/github/interfaces/_classes_.iprintinterface.md
@@ -36,7 +36,7 @@ It should be inherited by all subinterfaces.
 
 | Param | Type |
 | ------ | ------ |
-| value | `string` | 
+| value | `string` |
 
 **Returns:** `void`
 

--- a/test/fixtures/github/interfaces/_classes_.iprintnameinterface.md
+++ b/test/fixtures/github/interfaces/_classes_.iprintnameinterface.md
@@ -85,7 +85,7 @@ It should be inherited by all subinterfaces.
 
 | Param | Type |
 | ------ | ------ |
-| value | `string` | 
+| value | `string` |
 
 **Returns:** `void`
 

--- a/test/fixtures/github/interfaces/_interfaces_.interfaces.clockconstructor.md
+++ b/test/fixtures/github/interfaces/_interfaces_.interfaces.clockconstructor.md
@@ -28,8 +28,8 @@
 
 | Param | Type |
 | ------ | ------ |
-| hour | `number` | 
-| minute | `number` | 
+| hour | `number` |
+| minute | `number` |
 
 **Returns:** [ClockInterface](_interfaces_.interfaces.clockinterface.md)
 

--- a/test/fixtures/github/interfaces/_interfaces_.interfaces.clockinterface.md
+++ b/test/fixtures/github/interfaces/_interfaces_.interfaces.clockinterface.md
@@ -45,7 +45,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| d | `Date` | 
+| d | `Date` |
 
 **Returns:** `any`
 

--- a/test/fixtures/github/interfaces/_interfaces_.interfaces.surface.md
+++ b/test/fixtures/github/interfaces/_interfaces_.interfaces.surface.md
@@ -34,7 +34,7 @@
 
 | Param | Type |
 | ------ | ------ |
-| pos | [Vector](../classes/_interfaces_.vector.md) | 
+| pos | [Vector](../classes/_interfaces_.vector.md) |
 
 **Returns:** [Color](../classes/_interfaces_.color.md)
 
@@ -54,7 +54,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| pos | [Vector](../classes/_interfaces_.vector.md) | 
+| pos | [Vector](../classes/_interfaces_.vector.md) |
 
 **Returns:** `number`
 
@@ -83,7 +83,7 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| pos | [Vector](../classes/_interfaces_.vector.md) | 
+| pos | [Vector](../classes/_interfaces_.vector.md) |
 
 **Returns:** [Color](../classes/_interfaces_.color.md)
 

--- a/test/fixtures/github/modules/_functions_.md
+++ b/test/fixtures/github/modules/_functions_.md
@@ -87,11 +87,11 @@ This is a function with a parameter that has a default value.
 
 | Param | Type | Default value |
 | ------ | ------ | ------ |
-| `Default value` valueA | `string` | &quot;defaultValue&quot; | 
-| `Default value` valueB | `number` | 100 | 
-| `Default value` valueC | `number` |  Number.NaN | 
-| `Default value` valueD | `boolean` | true | 
-| `Default value` valueE | `boolean` | false | 
+| `Default value` valueA | `string` | &quot;defaultValue&quot; |
+| `Default value` valueB | `number` | 100 |
+| `Default value` valueC | `number` |  Number.NaN |
+| `Default value` valueD | `boolean` | true |
+| `Default value` valueE | `boolean` | false |
 
 **Returns:** `string`
 The input value or the default value.

--- a/test/fixtures/github/modules/_interfaces_.interfaces.md
+++ b/test/fixtures/github/modules/_interfaces_.interfaces.md
@@ -46,8 +46,8 @@
 
 | Param | Type |
 | ------ | ------ |
-| source | `string` | 
-| subString | `string` | 
+| source | `string` |
+| subString | `string` |
 
 **Returns:** `boolean`
 
@@ -88,9 +88,9 @@ ___
 
 | Param | Type |
 | ------ | ------ |
-| ctor | [ClockConstructor](../interfaces/_interfaces_.interfaces.clockconstructor.md) | 
-| hour | `number` | 
-| minute | `number` | 
+| ctor | [ClockConstructor](../interfaces/_interfaces_.interfaces.clockconstructor.md) |
+| hour | `number` |
+| minute | `number` |
 
 **Returns:** [ClockInterface](../interfaces/_interfaces_.interfaces.clockinterface.md)
 

--- a/test/src/classes.ts
+++ b/test/src/classes.ts
@@ -272,6 +272,15 @@ export class SubClassB extends BaseClass {
 
   doSomething(value: [string, SubClassA, SubClassB]) {
   }
+
+  /**
+   * Description for doOtherThings.
+   *
+   * @param value Description for value
+   * @param secondValue Description for optional value
+   */
+  doOtherThings(value: string | number | SubClassA, secondValue?: SubClassA) {
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #27.

* Replaced the `|` with the html entity code `&#124;` in the `type.hbs` and removed some white spaces.
* Added a method in a test class with a parameter which can have different types
* Had to update the test fixtures (mainly because of the remove white space)