### PR TITLE
Change type alias prefix symbol and formatting to avoid confusion.

### DIFF
--- a/src/theme/helpers/getMemberSymbol.ts
+++ b/src/theme/helpers/getMemberSymbol.ts
@@ -12,7 +12,7 @@ export function getMemberSymbol(kindString: string) {
       symbol = '▸ ';
       break;
     case 'Type alias':
-      symbol = 'Τ';
+      symbol = 'Ƭ ';
       break;
     case 'Property':
     case 'Variable':

--- a/test/fixtures/bitbucket/modules/interfaces.md
+++ b/test/fixtures/bitbucket/modules/interfaces.md
@@ -33,7 +33,7 @@
 
 ###  SearchFunc
 
-**ΤSearchFunc**: *`function`*
+**Ƭ SearchFunc**: *`function`*
 
 *Defined in [interfaces.ts:62](https://bitbucket.org/owner/repository_name/src/master/interfaces.ts?fileviewer&amp;#x3D;file-view-default#interfaces.ts-62)*
 

--- a/test/fixtures/gitbook/modules/_interfaces_.interfaces.md
+++ b/test/fixtures/gitbook/modules/_interfaces_.interfaces.md
@@ -33,7 +33,7 @@
 
 ##  SearchFunc
 
-**ΤSearchFunc**: *`function`*
+**Ƭ SearchFunc**: *`function`*
 
 *Defined in [interfaces.ts:62](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L62)*
 

--- a/test/fixtures/github/modules/_interfaces_.interfaces.md
+++ b/test/fixtures/github/modules/_interfaces_.interfaces.md
@@ -35,7 +35,7 @@
 
 ###  SearchFunc
 
-**ΤSearchFunc**: *`function`*
+**Ƭ SearchFunc**: *`function`*
 
 *Defined in [interfaces.ts:62](https://github.com/tgreyjs/typedoc-plugin-markdown/blob/master/test/src/interfaces.ts#L62)*
 


### PR DESCRIPTION
The current prefix is a capital "T" with no trailing space. This results in confusing definitions making it look like the actual type alias starts with "T". To address this, I made the following changes:

* Added a space after type alias prefix.
* Changed type alias prefix to a not english [UTF8 character resembling "T"](https://www.fileformat.info/info/unicode/char/01ac/browsertest.htm).

